### PR TITLE
docs: inicializa gobernanza del repo (contribuir, conducta, templates, license)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @franciscavillar

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,10 @@
+---
+name: Reporte de bug
+about: Crea un reporte de error
+labels: bug
+---
+### Descripción
+### Pasos para reproducir
+### Esperado vs actual
+### Evidencia
+### Entorno

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,9 @@
+---
+name: Solicitud de funcionalidad
+about: Propón una mejora
+labels: enhancement
+---
+### Problema a resolver
+### Propuesta
+### Criterios de aceptación
+### Impacto

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Descripción
+## Cómo probar
+## Checklist
+- [ ] CI verde
+- [ ] Sin errores en consola
+- [ ] Docs actualizadas
+- [ ] Closes #N
+## Evidencia

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+## [1.0.0] - 2025-09-08
+### Added
+- Documentación inicial (contribuir, conducta, templates, CODEOWNERS, LICENSE)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Código de Conducta
+Ambiente abierto, inclusivo y respetuoso. No se tolera acoso o discriminación.
+Reporte por Issues o correo del mantenedor.

--- a/CONTRIBUYENDO.md
+++ b/CONTRIBUYENDO.md
@@ -1,0 +1,4 @@
+- Ramas: `feat/<slug>`, `fix/<slug>`, `docs/<slug>`
+- Commits: Conventional Commits (feat, fix, docs, style, refactor, test, chore)
+- PRs pequeños con “Cómo probar” y CI en verde
+- DoD: funciona, sin errores en consola, docs actualizadas

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,3 @@
+MIT License
+Copyright (c) 2025
+Permission is hereby granted, free of charge, to any person obtaining a copy...


### PR DESCRIPTION
Este PR agrega la base de gobernanza del proyecto, incluyendo:

- CONTRIBUYENDO.md
- CODE_OF_CONDUCT.md
- CHANGELOG.md
- LICENSE
- Plantillas para issues y PRs
- CODEOWNERS

## Checklist
- [x] Archivos principales creados
- [x] Estructura `.github` lista
- [x] Rama revisada y lista para merge
